### PR TITLE
Fixed compile-time issues

### DIFF
--- a/lib/app_component.html
+++ b/lib/app_component.html
@@ -3,5 +3,5 @@
 
     <h1>My First AngularDart App</h1>
 
-    <todo-list></todo-list>
+    <form_component></form_component>
 </body>

--- a/lib/src/components/form_component/form_component.dart
+++ b/lib/src/components/form_component/form_component.dart
@@ -5,14 +5,17 @@ import 'package:energized_id/energized_id.dart';
 
 @Component(
   selector: 'form_component',
-  templateUrl: ['form_component.html'],
+  templateUrl: 'form_component.html',
   directives: [coreDirectives, formDirectives],
 )
 class form_component {
-  Student model = Student('Micah', 'Guttman', 10);
+  Student model = Student()
+    ..firstName = "Micah"
+    ..lastName = "Guttman"
+    ..gradeLevel = 10;
   bool submitted = false;
 
-  List<String> get powers => _powers;
+  //List<String> get powers => _powers;
 
   void onSubmit() => submitted = true;
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -11,14 +11,14 @@ dependencies:
   angular: ^5.2.0
   angular_bloc: ^0.9.0
   http: ^0.12.0
-  angular_components: ^0.12.0
+  angular_components: ^0.13.0
 
   energized_id:
     git: https://github.com/energized-id/energized_id.git
 
 dev_dependencies:
   angular_test: ^2.2.0
-  build_runner: ^1.1.2
+  build_runner: '>=1.6.2 <2.0.0'
   build_test: ^0.10.3
   build_web_compilers: ^1.0.0
   json_serializable: ^3.0.0


### PR DESCRIPTION
All compile-time issues have been fixed. The page can be displayed via `webdev serve`.

Here is an overview of what files have been changed:

#### lib/src/components/form_component/form_component.dart
- The `templateUrl` of the `@Component` annotation takes a `String`, not a `List`. A component can only have one template. Contrast with `styleUrls`, which does take a `List` and was probably the source of your confusion; components can include many stylesheets, which all get applied similarly to having multiple `<link>` tags on the same HTML document. This problem would have been explained to you by hovering over the red squiggles beneath your `List`, which I recommend you do to see what it looks like before merging this pull request. (I assume here and in later bullet points that you are still using VS Code with the Dart plugin. If you have suddenly decided that modern IDEs are for suckers, you can see the same error messages I describe by running `dartanalyzer .` from the package root directory.)
- The `Student` class constructor does not declare any positional arguments; instead, a `Student` object's properties may be quickly set using the cascade operator (`..`). The lack of constructor parameters would have been indicated by a red squiggle and elaborated upon when moused over. The decision to use cascades rather than constructor parameters was made for two major reasons:
  - *It improves readability.* In your original sample, while the roles of 'Micah' and 'Guttman' were relatively clear, someone reading the code would not necessarily know what the 10 meant. In cascade notation, values are paired with their property names, making it much clearer that the 10 is, in fact, your grade level.
  - *It avoids duplication of information.* Say that, in the future, you need to add a new property to the `Student` class. If fields were set in constructor parameters, the new field would then also need to be added to the constructor, or else it couldn't be used. If the type of a field needed to be changed, it would also need to be changed in the constructor, which could introduce bugs if the latter step was forgotten.
    - As a relevant side note, if you are looking for humorous and informative reading material, I highly recommend [How to Write Unmaintainable Code](https://www.se.rit.edu/~tabeec/RIT_441/Resources_files/How%20To%20Write%20Unmaintainable%20Code.pdf) (PDF link) by Roedy Green. It offers numerous fine counterexamples of good coding behavior, focusing heavily on C and Java. Of note here is the introductory paragraph of the "Program Design" section.
- Student forms do not have powers. Presumably, that line was a leftover from copying from the Tour of Heroes. Again, this line would have had red squiggles indicating that the `_powers` getter did not exist.

#### lib/app_component.html
- The reference to the no-longer-existent `<todo-list>` tag was replaced with your `<form_component>` tag (as defined by the `selector` field in the `@Component` annotation). Again, there would have been squiggles in this file telling you about this problem, though they would have been yellow this time.

#### pubspec.yaml
- Attempting to run `webdev serve` from this package resulted in an error message about your dev dependency on a too-old version of `build_runner`. The version constraints were updated to match those presented by `webdev`; in addition, your dependency on `angular_components` was updated to a newer version in order to resolve a dependency conflict with the new version of `build_runner`:
```
Because no versions of angular_components match >0.12.0 <0.13.0 and angular_components 0.12.0 depends on build_config >=0.2.6 <0.4.0, angular_components ^0.12.0 requires build_config >=0.2.6 <0.4.0.
Because build_runner >=1.6.5 depends on build_config >=0.4.1 <0.4.2 and build_runner >=1.3.4 <1.6.5 depends on build_config >=0.4.0 <0.4.1, build_runner >=1.3.4 requires build_config >=0.4.0 <0.4.1 or >=0.4.1 <0.4.2.
Thus, angular_components ^0.12.0 is incompatible with build_runner >=1.3.4.
So, because Energized_ID_UI depends on both angular_components ^0.12.0 and build_runner ^1.6.2, version solving failed.
```